### PR TITLE
fix(ci): handle missing brew in bootstrap and auto-detect sibling ptyunit

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
-# bootstrap.sh — Install fissible consumer dependencies
+# bootstrap.sh — Install fissible consumer dependencies (macOS/Homebrew only)
+# In CI, ptyunit is checked out as a sibling directory by the shared workflow.
+if ! command -v brew >/dev/null 2>&1; then
+    printf 'bootstrap.sh: brew not found, skipping (expected in CI)\n'
+    exit 0
+fi
 brew install fissible/tap/ptyunit 2>/dev/null || brew upgrade fissible/tap/ptyunit

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,11 +9,16 @@
 set -u
 
 if [[ -z "${PTYUNIT_HOME:-}" ]]; then
-    _prefix=$(brew --prefix ptyunit 2>/dev/null) || {
+    # Check for sibling ptyunit checkout (used in CI and local fissible workspace)
+    _sibling="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/ptyunit"
+    if [[ -f "$_sibling/run.sh" ]]; then
+        PTYUNIT_HOME="$_sibling"
+    elif _prefix=$(brew --prefix ptyunit 2>/dev/null); then
+        PTYUNIT_HOME="$_prefix/libexec"
+    else
         printf 'error: ptyunit not found. Run: bash bootstrap.sh\n' >&2
         exit 1
-    }
-    PTYUNIT_HOME="$_prefix/libexec"
+    fi
 fi
 
 if [[ ! -f "$PTYUNIT_HOME/run.sh" ]]; then


### PR DESCRIPTION
## Summary

- `bootstrap.sh` exits cleanly (exit 0) when `brew` is not found, fixing the `command not found: brew` failure on Ubuntu CI runners
- `tests/run.sh` checks for a sibling `ptyunit/` directory before falling back to `brew --prefix`, matching how the shared `test-bash.yml` workflow provisions ptyunit via `actions/checkout`

## Test plan

- [ ] CI passes on both `macos-latest` and `ubuntu-latest` runners
- [ ] Local macOS: `bash bootstrap.sh` still installs/upgrades via Homebrew
- [ ] Local macOS: `bash tests/run.sh` still resolves ptyunit via brew fallback when no sibling exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)